### PR TITLE
Feature/cleanup new samples

### DIFF
--- a/src/AddIn.FindByUser/FindByUserConfigurationDialog.cs
+++ b/src/AddIn.FindByUser/FindByUserConfigurationDialog.cs
@@ -34,6 +34,8 @@ namespace Gibraltar.AddIn.FindByUser
                 newConfig.ConnectionString = txtConnectionString.Text;
                 newConfig.AutoScanSessions = chkEnableAutoScan.Checked;
 
+                configuration.Machine = newConfig; // this is redundant except in the crucial first-time initialization case!
+
                 LogConfigurationChanges(newConfig, oldConfig);
             }
             else

--- a/src/AddIn.FindByUser/FindByUserDatabase.cs
+++ b/src/AddIn.FindByUser/FindByUserDatabase.cs
@@ -120,9 +120,9 @@ namespace Gibraltar.AddIn.FindByUser
                     AddParameter(command, "@sessionId", sessionId);
                     AddParameter(command, "@sessionDate", sessionDate);
 
-                    var key = (int?) command.ExecuteScalar();
-                    if (key.HasValue)
-                        sessionKey = key.Value;
+                    var key = command.ExecuteScalar();
+                    if (key != null)
+                        sessionKey = Convert.ToInt32(key);
                 }
 
                 // If not, add one now
@@ -134,9 +134,9 @@ namespace Gibraltar.AddIn.FindByUser
                                               + "(@sessionId, @sessionDate); select @@identity";
                         AddParameter(command, "@sessionId", sessionId);
                         AddParameter(command, "@sessionDate", sessionDate);
-                        var key = (int?) command.ExecuteScalar();
-                        if (key.HasValue)
-                            sessionKey = key.Value;
+                        var key = command.ExecuteScalar();
+                        if (key != null)
+                            sessionKey = Convert.ToInt32(key);
                     }
                 }
 
@@ -154,9 +154,9 @@ namespace Gibraltar.AddIn.FindByUser
                     {
                         command.CommandText = "select id from dbo.Username where Username = @username";
                         AddParameter(command, "@username", user);
-                        var key = (int?) command.ExecuteScalar();
-                        if (key.HasValue)
-                            userKey = key.Value;
+                        var key = command.ExecuteScalar();
+                        if (key != null)
+                            userKey = Convert.ToInt32(key);
                     }
 
                     // If not, add the user
@@ -167,9 +167,9 @@ namespace Gibraltar.AddIn.FindByUser
                             command.CommandText = "insert into dbo.Username (Username) values "
                                                   + "(@username); select @@identity";
                             AddParameter(command, "@username", user);
-                            var key = (int?) command.ExecuteScalar();
-                            if (key.HasValue)
-                                userKey = key.Value;
+                            var key = command.ExecuteScalar();
+                            if (key != null)
+                                userKey = Convert.ToInt32(key);
                         }
                     }
 
@@ -185,11 +185,11 @@ namespace Gibraltar.AddIn.FindByUser
                                               + "Session_FK = @sessionKey and User_FK = @userKey";
                         AddParameter(command, "@sessionKey", sessionKey);
                         AddParameter(command, "@userKey", userKey);
-                        var count = (int?) command.ExecuteScalar();
+                        var count = command.ExecuteScalar();
 
                         // If the user is already associated with this session,
                         // there's nothing more to do for this user
-                        if (count.HasValue && count.Value  > 0)
+                        if (count != null && Convert.ToInt32(count) > 0)
                             continue;
                     }
 

--- a/src/AddIn.FindByUser/SessionAnalyzer.cs
+++ b/src/AddIn.FindByUser/SessionAnalyzer.cs
@@ -167,13 +167,26 @@ namespace Gibraltar.AddIn.FindByUser
             if (!skipScan)
             {
                 var missingSessions = 0;
+                var localSession = 0;
                 foreach (var summary in sessionSummaries)
                 {
                     if (summary.HasData)
-                        ScanSession(summary.Session());
+                        try
+                        {
+                            ScanSession(summary.Session());
+                        }
+                        catch (NotImplementedException ex)
+                        {
+                            localSession++;
+                            missingSessions++;
+                        }
                     else
                         missingSessions++;
                 }
+
+                if (localSession > 0)
+                    _addInContext.Log.Warning(FindByUserAddIn.LogCategory, "AddIns are not compatible with local sessions",
+                        "This will be corrected in a future version of Loupe Desktop.");
 
                 var description = string.Format("{0} sessions scanned.", sessionSummaries.Count);
                 if (missingSessions > 0)


### PR DESCRIPTION
This patch resolves a couple defects that users encountered running the FindByUser add-in:
- The add-in configuration was not being properly initialized
- The result of ExecuteScalar needed to be tested for null then passed to Convert.ToInt32 rather than just assigned to an int?
- Guard logic was added to ignore local sessions which are unsupported for scanning. 
