### PR TITLE
Moved add-in configuration from Machine to Common repository

### DIFF
--- a/src/AddIn.Export/ExportConfigurationDialog.cs
+++ b/src/AddIn.Export/ExportConfigurationDialog.cs
@@ -29,7 +29,7 @@ namespace Gibraltar.AddIn.Export
         {
             context.Log.Verbose(LogCategory, "Begin editing Session Export config", null);
 
-            _configuration = configuration.Machine as ExportAddInConfiguration ?? new ExportAddInConfiguration();
+            _configuration = configuration.Common as ExportAddInConfiguration ?? new ExportAddInConfiguration();
 
             DisplayConfiguration(context);
 
@@ -60,7 +60,7 @@ namespace Gibraltar.AddIn.Export
                     context.Log.Error(LogCategory, "Could not parse Log Message Severity", "Selected value: {0}", cboMinimumSeverity.Text);
                 _configuration.MinimumSeverity = severity;
 
-                configuration.Machine = _configuration;
+                configuration.Common = _configuration;
 
                 LogConfigurationChanges(context, oldConfig);
             }

--- a/src/AddIn.Export/SessionExportDefinition.cs
+++ b/src/AddIn.Export/SessionExportDefinition.cs
@@ -21,7 +21,7 @@ namespace Gibraltar.AddIn.Export
         public SessionExportDefinition(IRepositoryAddInContext context)
         {
             _context = context;
-            Config = context.Configuration.Machine as ExportAddInConfiguration;
+            Config = context.Configuration.Common as ExportAddInConfiguration;
             if (Config == null)
                 return; // Enabled is false
 

--- a/src/AddIn.Export/SessionExporter.cs
+++ b/src/AddIn.Export/SessionExporter.cs
@@ -156,7 +156,7 @@ namespace Gibraltar.AddIn.Export
         /// <param name="sessionSummary"></param>
         private void ProcessViewCommand(ISessionSummary sessionSummary)
         {
-            var configuration = _addInContext.Configuration.Machine as ExportAddInConfiguration;
+            var configuration = _addInContext.Configuration.Common as ExportAddInConfiguration;
             if (configuration == null
                 || string.IsNullOrEmpty(configuration.SessionExportPath)
                 || !Directory.Exists(configuration.SessionExportPath))

--- a/src/AddIn.FindByUser/FindByUserConfigurationDialog.cs
+++ b/src/AddIn.FindByUser/FindByUserConfigurationDialog.cs
@@ -20,7 +20,7 @@ namespace Gibraltar.AddIn.FindByUser
             _context = context;
             _context.Log.Verbose(FindByUserAddIn.LogCategory, "Begin editing Session Alert config", null);
 
-            var newConfig = configuration.Machine as FindByUserConfiguration ?? new FindByUserConfiguration();
+            var newConfig = configuration.Common as FindByUserConfiguration ?? new FindByUserConfiguration();
 
             DisplayConfiguration(newConfig);
 
@@ -34,7 +34,7 @@ namespace Gibraltar.AddIn.FindByUser
                 newConfig.ConnectionString = txtConnectionString.Text;
                 newConfig.AutoScanSessions = chkEnableAutoScan.Checked;
 
-                configuration.Machine = newConfig; // this is redundant except in the crucial first-time initialization case!
+                configuration.Common = newConfig; // this is redundant except in the crucial first-time initialization case!
 
                 LogConfigurationChanges(newConfig, oldConfig);
             }

--- a/src/AddIn.FindByUser/FindByUserDatabase.cs
+++ b/src/AddIn.FindByUser/FindByUserDatabase.cs
@@ -11,7 +11,7 @@ namespace Gibraltar.AddIn.FindByUser
     {
         public static FindByUserDatabase GetDatabase(IRepositoryAddInContext context)
         {
-            var config = context.Configuration.Machine as FindByUserConfiguration;
+            var config = context.Configuration.Common as FindByUserConfiguration;
             if (config == null)
                 return null;
 

--- a/src/AddIn.FindByUser/SessionAnalyzer.cs
+++ b/src/AddIn.FindByUser/SessionAnalyzer.cs
@@ -57,7 +57,7 @@ namespace Gibraltar.AddIn.FindByUser
         /// </summary>
         void ISessionAnalyzer.Process(ISession session)
         {
-            var config = _addInContext.Configuration.Machine as FindByUserConfiguration;
+            var config = _addInContext.Configuration.Common as FindByUserConfiguration;
             if (config == null || config.AutoScanSessions == false)
                 return;
 

--- a/src/AddIn/SampleConfigurationDialog.cs
+++ b/src/AddIn/SampleConfigurationDialog.cs
@@ -23,7 +23,7 @@ namespace Gibraltar.AddIn.Test
         /// </returns>
         public DialogResult EditConfiguration(IAddInContext context, IAddInConfiguration configuration, bool initialConfiguration)
         {
-            m_Configuration = configuration.Machine as SampleAddInConfiguration ?? new SampleAddInConfiguration();
+            m_Configuration = configuration.Common as SampleAddInConfiguration ?? new SampleAddInConfiguration();
 
             DisplayConfiguration();
 
@@ -33,7 +33,7 @@ namespace Gibraltar.AddIn.Test
                 //copy back our changes.
                 m_Configuration.AutoExportSessions = chkEnableAutoExport.Checked;
                 m_Configuration.SessionExportPath = txtSessionExportPath.Text;
-                configuration.Machine = m_Configuration;
+                configuration.Common = m_Configuration;
             }
 
             return result;

--- a/src/AddIn/SessionAnalysisAddInSample.cs
+++ b/src/AddIn/SessionAnalysisAddInSample.cs
@@ -57,7 +57,7 @@ namespace Gibraltar.AddIn.Test
             //we're going to read the config here and save what we care about so we don't have to 
             //deal with error handling during the process phase.
 
-            SampleAddInConfiguration configuration = m_AddInContext.Configuration.Machine as SampleAddInConfiguration;
+            SampleAddInConfiguration configuration = m_AddInContext.Configuration.Common as SampleAddInConfiguration;
 
             if (configuration == null)
             {


### PR DESCRIPTION
The configuration data for the Loupe.Samples addins was stored in the Machine repository which is fine for add-ins run exclusively in Loupe Desktop.  However, to all add-ins to run either in Loupe Desktop or Loupe Server it would be more appropriate to store this configuration data in the Common repository.  Note that this approach assumes that all configuration data including connection strings and file paths would be valid when referenced from either Desktop or Server.
