### PR TITLE
Added option to log warnings on excessive duration

### DIFF
--- a/src/Caliper/MainForm.Designer.cs
+++ b/src/Caliper/MainForm.Designer.cs
@@ -33,6 +33,7 @@
             this.btnStopWorking = new System.Windows.Forms.Button();
             this.btnWorkRepeatedly = new System.Windows.Forms.Button();
             this.nudWorkRepeatedly = new System.Windows.Forms.NumericUpDown();
+            this.cbTwoSeconds = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.nudWorkRepeatedly)).BeginInit();
             this.SuspendLayout();
             // 
@@ -104,11 +105,24 @@
             0,
             0});
             // 
+            // cbTwoSeconds
+            // 
+            this.cbTwoSeconds.AutoSize = true;
+            this.cbTwoSeconds.Checked = true;
+            this.cbTwoSeconds.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cbTwoSeconds.Location = new System.Drawing.Point(13, 246);
+            this.cbTwoSeconds.Name = "cbTwoSeconds";
+            this.cbTwoSeconds.Size = new System.Drawing.Size(98, 17);
+            this.cbTwoSeconds.TabIndex = 2;
+            this.cbTwoSeconds.Text = "Warn if > 2 sec";
+            this.cbTwoSeconds.UseVisualStyleBackColor = true;
+            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(134, 250);
+            this.ClientSize = new System.Drawing.Size(128, 273);
+            this.Controls.Add(this.cbTwoSeconds);
             this.Controls.Add(this.nudWorkRepeatedly);
             this.Controls.Add(this.btnWorkRepeatedly);
             this.Controls.Add(this.btnStopWorking);
@@ -122,6 +136,7 @@
             this.Text = "Caliper Tests";
             ((System.ComponentModel.ISupportInitialize)(this.nudWorkRepeatedly)).EndInit();
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
@@ -132,6 +147,7 @@
         private System.Windows.Forms.Button btnStopWorking;
         private System.Windows.Forms.Button btnWorkRepeatedly;
         private System.Windows.Forms.NumericUpDown nudWorkRepeatedly;
+        private System.Windows.Forms.CheckBox cbTwoSeconds;
     }
 }
 

--- a/src/Caliper/MainForm.cs
+++ b/src/Caliper/MainForm.cs
@@ -2,7 +2,7 @@
 using System.Diagnostics;
 using System.Threading;
 using System.Windows.Forms;
-using Gibraltar.Log;
+using Gibraltar.Agent;
 
 namespace CaliperTest
 {
@@ -35,17 +35,21 @@ namespace CaliperTest
         /// measure execution time for non-contiguous blocks of code for
         /// which a using block is not viable.
         /// </summary>
-        readonly Caliper _timer = new Caliper("Tests.StartStop");
+        private Caliper _timer;
         private void btnStartWorking_Click(object sender, EventArgs e)
         {
+            if (cbTwoSeconds.Checked)
+                _timer = new Caliper("Tests.StartStop", new TimeSpan(0,0,2));
+            else
+                _timer = new Caliper("Tests.StartStop");
             Trace.WriteLine("Start Working...");
             _timer.Start();
         }
 
         private void btnStopWorking_Click(object sender, EventArgs e)
         {
-            Trace.WriteLine("Stop Working");
             _timer.Stop();
+            Trace.WriteLine("Stop Working after " + Math.Round(_timer.Elapsed.TotalSeconds, 3) + " seconds");
         }
 
         /// <summary>

--- a/src/Caliper/Program.cs
+++ b/src/Caliper/Program.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Windows.Forms;
 using Gibraltar.Agent;
-using Gibraltar.Log;
 
 namespace CaliperTest
 {

--- a/src/Caliper/Properties/AssemblyInfo.cs
+++ b/src/Caliper/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Demo")]
-[assembly: AssemblyCopyright("Copyright © Gibraltar Software 2014")]
+[assembly: AssemblyCopyright("Copyright © Gibraltar Software 2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 


### PR DESCRIPTION
This enhancement adds an optional TimeSpan parameter to the constructor of a Caliper.  If the duration of the Caliper exceeds the WarningTime, then a warning message will be logged.
